### PR TITLE
Refactor schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                     <li>Add Item - Adds a new Item to the partition.</li>
                     <li>Paste Item - Adds a copied Item to the partition.</li>
                     <li>Delete Partition - Deletes all Items in this partition from the table.</li>
-                    <li>Edit Mapping - Define a Mapping Function to generate the Partition Key value.</li>
+                    <li>Edit Value Template - Define a value template to generate the Partition Key value.</li>
                     <li>Move Up/Down - Change the position of the partition on the table.</li>
                 </ol>
                 <h4 tabindex="-1">Sort Key Menu</h4>
@@ -130,7 +130,7 @@
                     <li>Cut Item - Removes the Item from the Table and copies it to the clipboard.</li>
                     <li>Copy Item - Copies the Item to the clipboard.</li>
                     <li>Delete Item - Removes the Item from the Table.</li>
-                    <li>Edit Mapping - Define a Mapping Function to generate the Sort Key value.</li>
+                    <li>Edit Value Template - Define a value template to generate the Sort Key value.</li>
                     <li>Generate Value - Inserts either an ISO Date or UUID string as the Sort Key value.</li>
                 </ol>
                 <h4 tabindex="-1">Attribute Menu</h4>
@@ -139,22 +139,23 @@
                 <ol>
                     <li>Delete Attribute - Removes the Attribute from the Item.</li>
                     <li>Cut Item - Removes the Item from the Table and copies it to the clipboard.</li>
-                    <li>Edit Mapping - Define a Mapping Function to generate the Attribute value.</li>
+                    <li>Edit Value Template - Define a value template to generate the Attribute value.</li>
                     <li>Generate Value - Inserts either an ISO Date or UUID string as the Attribute value.</li>
                 </ol>
-                <h3 tabindex="-1">Mapping Functions</h3>
-                <p>Attributes can be assigned Mapping Functions to generate their Associated values.  Mapping Functions are associated to Attributes by Item type. When an Item is created or modified the type of the Item will determine any Mapping Functions that should be used to generate Attribute values. When the 'Edit Mapping' option is selected the following modal dialogue will appear:</p>
+                <h3 tabindex="-1">Value Templates</h3>
+                <p>Attributes can be assigned value templates to generate their Associated values. Value templates are associated to Attributes by Item type. When an Item is created or modified the type of the Item will determine any value templates that should be used to generate Attribute values. When the 'Edit Value Template' option is selected the following modal dialogue will appear:</p>
                 <image src="./img/MappingFunction.png"></image><br><br>
-                <p>Currently the only operation supported for Mapping Functions is concatenation of other Attributes into a composite key. To combine Attribute values simply reference the attribute name as shown in the screenshot. Any text outside of the '${}' syntax will appear as typed in the final value.</p>
+                <p>Currently the only operation supported for value template is concatenation of other Attributes into a composite attribute. To combine Attribute values simply reference the attribute name as shown in the screenshot. Any text outside of the '${}' syntax will appear as typed in the final value.</p>
+
                 <h3 tabindex="-1">OneTable Integration</h3>
-                <p>If you use <a href="https://github.com/sensedeep/dynamodb-onetable">OneTable</a> you can now import and export your schema files into and out of the DynamoDB Datamodel using the convenient links on the Side Panel menu. To import, simply paste your JSON OneTable Schema into the dialog and you will be able to create Items using the Entity types defined in the OneTable schema. When creating items, set the "type" attribute to the entity type to populate all the other entity attributes. Currently only Table and Entity schema are imported, value mappings are not yet supported. Exported schemas are saved to a file in a multi-line JSON format.</p>
+                <p>If you use <a href="https://github.com/sensedeep/dynamodb-onetable">OneTable</a> you can now import and export your schema files into and out of the DynamoDB Datamodel using the convenient links on the Side Panel menu. To import, simply paste your JSON OneTable Schema into the dialog and you will be able to create Items using the Entity types defined in the OneTable schema. When creating items, set the "type" attribute to the entity type to populate all the other entity attributes. Currently only Table and Entity schema are imported. Exported schemas are saved to a file in a multi-line JSON format.</p>
                 <image src="./img/OneTable.png"></image><br><br>
                 <p>That should be enough to get you going. Click the '☰ menu' icon in the upper right corner to import an existing model from NoSQL Workbench for DynamoDB or use the modeler to build a data model for your DynamoDB Table from scratch.</p>
                 <p>Have ideas or feature requests? Ping me on <a href="https://twitter.com/houlihan_rick">Twitter</a> and let me know!</p>
             </div>
         </div>
     </div>
-    
+
     <div tabindex="-1" style="text-align:center;">
         <div tabindex="-1" style="display:inline-block;">
             <div tabindex="-1" id="divTabs" style="width: 90%; margin-left: 5%;">
@@ -276,11 +277,11 @@
         </div>
     </div>
 
-    <!-- Define Mapping Dialogue -->
-    <div id="defineMapDiv" class="modal">
+    <!-- Define Value Template Dialogue -->
+    <div id="defineValueTemplateDiv" class="modal">
         <div style="width: 500px;" class="modal-content">
-            <h1 style="text-align: center">Edit Mapping Function</h1>
-            <label id="lblEditMap" class="key_label">Mapping Function:</label>
+            <h1 style="text-align: center">Edit Value Template</h1>
+            <label id="lblEditMap" class="key_label">Value Template:</label>
             <input id="txtMapFunction" type="text">
             <div id="selectTypeDiv" hidden>
                 <label id="lblSelectType" class="key_label">Select Type:</label>


### PR DESCRIPTION
This refactor creates a “schema” object that is the source of truth for item types. It renames object_types to schema.

Notes:

* Value templates are now run directly from the schema.
* OneTable imports use the OneTable schema directly
* WorkBench imports create the schema from the data. 
* If there are no "type" attributes, cannot effectively create a schema. Not quite sure what to do in this case.
* When attributes are created / removed, the schema track the changes
* The "undo" facility does not yet store the schema so you cannot undo schema changes yet.
* The show schema / values toggle now works for imported workbench models.
* This has only been lightly tested.

The schema signature is:

```
var schema = {
    indexes: { /*
        primary: { hash: 'partition-key-name', sort: 'sort-key-name' }
        gs1: { hash: 'partition-key-name', sort: 'sort-key-name' }
        ....
    */ },
    models: { /*
        map             String. Either simple attribute name or "attribute.property".
        default         String. Default value string or function.
        foreign         String. Reference to another entity model (model:keys)
        nulls           Boolean. Allow property to be set to null.
        required        Boolean. Attribute is always required.
        size            Number. Maximum size of the data value
        type            String: String, Boolean, Number, Date, Set, Buffer, Binary, Set, Object, Array
        validate        String. Regular expression to match data (/regexp/qualifiers)
        value           String|Function. Value string template, function (mapping function)
        unique          Boolean. Attribute must have a unique value
    */ },

    //  Future
    queries: {},
    data: {},
}

```
